### PR TITLE
Bugfix/DBI-54

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,1 +1,0 @@
-MONGO_URL= url do seu banco de dados

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.ts",
   "scripts": {
     "test": "npx jest --config=jest.config.ts",
-    "dev": "npx nodemon -r dotenv/config src/index.ts",
-    "start": "node -r dotenv/config dist/index.js",
-    "start:dev": "ts-node -r dotenv/config src/index.ts",
+    "dev": "npx nodemon src/index.ts",
+    "start": "node dist/index.js",
+    "start:dev": "ts-node src/index.ts",
     "build": "tsc",
     "lint:check": "npx eslint -c .eslintrc.json ./**/*.{ts,test.ts}",
     "lint:fix": "npx eslint -c .eslintrc.json --fix ./**/*.{ts,test.ts}",

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,11 +5,10 @@ import dotenv from 'dotenv';
 (() => {
   if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'development') {
     console.error(`
-    Variável de ambiente NODE_ENV não está definida corretamente.
+    Variável de ambiente NODE_ENV não está definida corretamente, 'environments/.env.dev' será utilizado como default.
     Certifique-se que a variável NODE_ENV está definida como 'development' ou 'production' na sua máquina.
     Para mais informações, veja: https://stackoverflow.com/questions/11104028/why-is-process-env-node-env-undefined
   `);
-    return;
   }
 
   try {


### PR DESCRIPTION
### Problemas definindo variável de ambiente no windows

Estávamos tendo problemas definindo as variáveis de ambiente no windows, então o default agora é carregar o `.env.dev` dentro da pasta environments.