### PR TITLE
bugfix/DBI-ISSUE-76 - Códigos de retorno dos controllers

### DIFF
--- a/src/app/controllers/CategoriesController.ts
+++ b/src/app/controllers/CategoriesController.ts
@@ -42,6 +42,15 @@ export class CategoriesController {
     }
   }
 
+  async consultCategories(req: Request, res: Response) {
+    try {
+      const categories = await this.repository.getById(req.params.id);
+      res.status(200).json({ data: categories });
+    } catch (error) {
+      res.status(500).json({ message: error });
+    }
+  }
+
   async registerCategory(req: Request, res: Response) {
     try {
       const categories = await this.repository.create(req.body);

--- a/src/app/controllers/CategoriesController.ts
+++ b/src/app/controllers/CategoriesController.ts
@@ -14,7 +14,7 @@ export class CategoriesController {
       const categories = await this.repository.list();
       res.status(200).json({ data: categories });
     } catch (error) {
-      res.status(400).json({
+      res.status(500).json({
         message: error,
       });
     }
@@ -45,20 +45,11 @@ export class CategoriesController {
   async registerCategory(req: Request, res: Response) {
     try {
       const categories = await this.repository.create(req.body);
-      res.status(200).json({ data: categories });
+      res.status(201).json({ data: categories });
     } catch (error) {
-      res.status(400).json({
+      res.status(500).json({
         message: error,
       });
-    }
-  }
-
-  async consultCategories(req: Request, res: Response) {
-    try {
-      const categories = await this.repository.getById(req.params.id);
-      res.status(200).json({ data: categories });
-    } catch (error) {
-      res.status(500).json({ message: error });
     }
   }
 }

--- a/src/app/controllers/DigitalContentsController.ts
+++ b/src/app/controllers/DigitalContentsController.ts
@@ -39,6 +39,8 @@ export class DigitalContentsController {
 
       if (!guide) return res.status(404).json({ message: 'Esse guia não existe' });
 
+      if (req.body.category && !category) return res.status(404).json({ message: 'Essa categoria não existe' });
+
       const { title, shortDescription } = req.body;
 
       const newDigitalContent: DigitalContents = {
@@ -53,7 +55,7 @@ export class DigitalContentsController {
       };
 
       const createdDigitalContent = await this.repository.create(newDigitalContent);
-      return res.status(200).json({ data: createdDigitalContent });
+      return res.status(201).json({ data: createdDigitalContent });
     } catch (error) {
       return res.status(500).json({
         message: error,

--- a/src/app/controllers/DigitalContentsController.ts
+++ b/src/app/controllers/DigitalContentsController.ts
@@ -39,7 +39,8 @@ export class DigitalContentsController {
 
       if (!guide) return res.status(404).json({ message: 'Esse guia não existe' });
 
-      if (req.body.category && !category) return res.status(404).json({ message: 'Essa categoria não existe' });
+      if (req.body.category && !category)
+        return res.status(404).json({ message: 'Essa categoria não existe' });
 
       const { title, shortDescription } = req.body;
 

--- a/src/app/middlewares/validator/ValidateSchema.ts
+++ b/src/app/middlewares/validator/ValidateSchema.ts
@@ -4,7 +4,7 @@ import { validationResult } from 'express-validator';
 function validateRequestSchema(req: Request, res: Response, next: NextFunction) {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    return res.status(405).json({ errors: errors.array() });
+    return res.status(400).json({ errors: errors.array() });
   }
   return next();
 }

--- a/tests/unit/app/controllers/CategoriesController.test.ts
+++ b/tests/unit/app/controllers/CategoriesController.test.ts
@@ -48,7 +48,7 @@ describe(CategoriesController.name, () => {
     await instance.getCategories(req, res);
     expect(CategoriesRepositoryMock).toBeCalled();
     expect(CategoriesRepositoryMock.prototype.list).toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         message: errorMessage,
@@ -113,7 +113,7 @@ describe(CategoriesController.name, () => {
 
     expect(CategoriesRepositoryMock).toBeCalled();
     expect(CategoriesRepositoryMock.prototype.create).toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         data: [],
@@ -132,7 +132,7 @@ describe(CategoriesController.name, () => {
     await instance.registerCategory(req, res);
     expect(CategoriesRepositoryMock).toBeCalled();
     expect(CategoriesRepositoryMock.prototype.create).toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         message: errorMessage,

--- a/tests/unit/app/controllers/DigitalContentsController.test.ts
+++ b/tests/unit/app/controllers/DigitalContentsController.test.ts
@@ -115,7 +115,7 @@ describe(DigitalContentsController.name, () => {
       createdDigitalContent,
     );
 
-    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         data: createdDigitalContent,

--- a/tests/unit/app/validator/GuidesValidator.test.ts
+++ b/tests/unit/app/validator/GuidesValidator.test.ts
@@ -42,7 +42,7 @@ describe('GuidesValidator Test', () => {
 
   it(`${validateRequestSchema.name}: 
   when the body is invalid should return response with status and error content`, () => {
-    const status = 405;
+    const status = 400;
     const errorsMessage = ['Invalide title', 'Invalid content'];
     const req = getMockReq();
     const isEmpty = jest.fn();

--- a/tests/unit/app/validator/ValidateSchema.test.ts
+++ b/tests/unit/app/validator/ValidateSchema.test.ts
@@ -17,7 +17,7 @@ describe('CategoriesValidator Test', () => {
 
   it(`${validateRequestSchema.name}: 
   when the body is invalid should return response with status and error content`, () => {
-    const status = 405;
+    const status = 400;
     const errorsMessage = ['Invalide title', 'Invalid content'];
     const req = getMockReq();
     const isEmpty = jest.fn();


### PR DESCRIPTION
## Descrição

Os códigos http de retorno de algumas funções do controller estavam meio errados. 

Também mudei o código de reposta do validador. Antes estava [405](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Status/405), que é o Method Not Allowed e a gente usa quando um método como POST ou DELETE ou qualquer outro não é permitido na rota específica. Mudei para o [400](), que é o Bad Request. Pra mim fez sentido pq o validador validou que aquela requisição não estava de acordo com o esperado, e portanto bad request. :man_shrugging:.

Por fim também adicionei a validação de que o id da categoria enviado no cadastro de um conteúdo digital existe de fato.

[edit] A é esqueci de falar tbm q a `consultGuides` por algum motivo tinha desaparecido do controller mas os testes dela já estavam lá. _(merges bugados talvez?)_. Agora que mergeeou a pr dela ta td certo, mas na hora n tava mergeado ent só copiei ela e colei no lugar que ela deveria estar. 
____

**Link do card:**
[Códigos de retorno dos controllers](https://trello.com/c/sm37oggB/61-issue-76-backend-c%C3%B3digos-de-retorno-dos-controllers)

____

## Checklist Code Review
Avaliar se todos os itens a seguir foram feitos. Os itens com `*` não são obrigatórios.

- [x] Foi adicionada a descrição da PR
- [x] Foi adicionado o link do card
- [x] A branch segue o padrão com o prefixo DBI
- [x] Está seguindo os padrões de prefixo do gitflow (feature, bugfix, hotfix, release)
- [x] O título da PR segue o padrão: ***Nome da branch - Título do card***
- [x] A PR está sendo enviada para a branch `develop`
- [x] O Repositório que a PR está sendo enviada é o [**dbinclui-org/dbinclui-backend**](https://github.com/dbinclui-org/dbinclui-backend)
- [x] Foi realizado os testes unitários *
- [ ] Foi realizado os testes de integração *
- [x] Foi adicionada as respectivas **labels**
- [x] A PR foi assinada
