### PR TITLE
Bugfix/versao mongo db bug

### DIFF
--- a/src/app/repositories/GuidesRepository.ts
+++ b/src/app/repositories/GuidesRepository.ts
@@ -33,15 +33,29 @@ class GuidesRepository {
       {
         $lookup: {
           from: 'categories',
-          localField: '_id',
-          foreignField: 'guide',
+          let: { guideId: '_id' },
           as: 'categories',
           pipeline: [
             {
+              $match: {
+                $expr: {
+                  $eq: ['$$guideId', '$guide'],
+                },
+              },
+            },
+            {
               $lookup: {
                 from: 'digitalContent',
-                localField: '_id',
-                foreignField: 'category',
+                let: { categoryId: '_id' },
+                pipeline: [
+                  {
+                    $match: {
+                      $expr: {
+                        $eq: ['$$categoryId', '$category'],
+                      },
+                    },
+                  },
+                ],
                 as: 'digitalContents',
               },
             },
@@ -51,10 +65,16 @@ class GuidesRepository {
       {
         $lookup: {
           from: 'digitalContent',
-          localField: '_id',
-          foreignField: 'guide',
+          let: { guideId: '_id' },
           as: 'digitalContents',
           pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $eq: ['$$guideId', '$guide'],
+                },
+              },
+            },
             {
               $match: { category: undefined },
             },

--- a/src/app/repositories/GuidesRepository.ts
+++ b/src/app/repositories/GuidesRepository.ts
@@ -33,7 +33,7 @@ class GuidesRepository {
       {
         $lookup: {
           from: 'categories',
-          let: { guideId: '_id' },
+          let: { guideId: '$_id' },
           as: 'categories',
           pipeline: [
             {
@@ -46,7 +46,7 @@ class GuidesRepository {
             {
               $lookup: {
                 from: 'digitalContent',
-                let: { categoryId: '_id' },
+                let: { categoryId: '$_id' },
                 pipeline: [
                   {
                     $match: {
@@ -65,7 +65,7 @@ class GuidesRepository {
       {
         $lookup: {
           from: 'digitalContent',
-          let: { guideId: '_id' },
+          let: { guideId: '$_id' },
           as: 'digitalContents',
           pipeline: [
             {


### PR DESCRIPTION
## Descrição

A versão do MongoDB no Atlas é a 4.4. POREEEEM a gente tava usando coisas da versão 5.0 que é _taranranranra_ **PAGA**! _esse capitalismo onde ja se viu_


[Aqui nesse link embaixo vcs vao ver o **new in version 5.0**](https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/#correlated-subqueries-using-concise-syntax)

Entao por isso a gnt tem que deixar o código desse jeito, por causa de compatibilidade. :pensive: 

____

**Link do card:**
Não tem card é aqui na loucura mesmo
____

## Checklist Code Review
Avaliar se todos os itens a seguir foram feitos. Os itens com `*` não são obrigatórios.

- [ ] Foi adicionada a descrição da PR
- [ ] Foi adicionado o link do card
- [ ] A branch segue o padrão com o prefixo DBI
- [ ] Está seguindo os padrões de prefixo do gitflow (feature, bugfix, hotfix, release)
- [ ] O título da PR segue o padrão: ***Nome da branch - Título do card***
- [ ] A PR está sendo enviada para a branch `develop`
- [ ] O Repositório que a PR está sendo enviada é o [**dbinclui-org/dbinclui-backend**](https://github.com/dbinclui-org/dbinclui-backend)
- [ ] Foi realizado os testes unitários *
- [ ] Foi realizado os testes de integração *
- [ ] Foi adicionada as respectivas **labels**
- [ ] A PR foi assinada
